### PR TITLE
Remove static rel="canonical"

### DIFF
--- a/web_apis.fnc
+++ b/web_apis.fnc
@@ -358,7 +358,6 @@ BEGIN
 <HTML>
 <HEAD>
   <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <LINK rel="canonical" href="https://crt.sh/">
   <TITLE>crt.sh | ' || html_escape(t_title) || '</TITLE>
   <META name="description" content="Free CT Log Certificate Search Tool from COMODO">
   <META name="keywords" content="crt.sh, CT, Certificate Transparency, Certificate Search, SSL Certificate, Comodo CA">


### PR DESCRIPTION
Currently every page claims to be the homepage. I'm guessing this was a placeholder, so if you'd prefer it to calculate an actual canonical URL for the various queries, I'm happy to have a go at that instead.